### PR TITLE
fixed handling of no arguments

### DIFF
--- a/sh/ups_status.sh
+++ b/sh/ups_status.sh
@@ -2,7 +2,7 @@
 
 ups=$1
 
-if [ $ups = ups.discovery ]; then
+if [[ $ups = ups.discovery ]]; then
 
     echo -e "{\n\t\"data\":["
     first=1


### PR DESCRIPTION
updated bash test to match line 21 syntax AND handle case where script is called without arguments (at least on linux with bash 5.2.32):

BEFORE:
    $ ./ups_status.sh 
    ./ups_status.sh: line 5: [: =: unary operator expected
    Error: invalid UPS definition.
    Required format: upsname[@hostname[:port]]

AFTER:
    $ ./ups_status.sh 
    Error: invalid UPS definition.
    Required format: upsname[@hostname[:port]]
